### PR TITLE
update meta tags format to RDFa spec

### DIFF
--- a/views/partials/homepage-header.ejs
+++ b/views/partials/homepage-header.ejs
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta atono-env="dev" />
-        <meta atono-tenant="Tobias" />
+        <meta property="atono:environment" content="DrtAH82dFpTjBjkLQQNgFK_aQcsnab-6NHM-HV7gpOIP">
+        <meta property="atono:tenancy" content="Tobias">
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta

--- a/views/partials/subpage-header.ejs
+++ b/views/partials/subpage-header.ejs
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta atono-env="dev" />
-        <meta atono-tenant="Tobias" />
+        <meta property="atono:environment" content="DrtAH82dFpTjBjkLQQNgFK_aQcsnab-6NHM-HV7gpOIP">
+        <meta property="atono:tenancy" content="Tobias">
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta


### PR DESCRIPTION
Updates meta tags to use the RDFa spec for environment and tenancy, as well as using the key for the environment rather than its name